### PR TITLE
Enhance theme toggle and mobile menu styles for UI consistency

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -179,6 +179,14 @@
     transition: color 0.2s ease;
 }
 
+.theme-toggle,
+.mobile-menu {
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    border: 0;
+}
+
 .mobile-menu:hover {
     color: var(--primary-600);
 }


### PR DESCRIPTION
This pull request makes a minor update to the CSS for theme toggle and mobile menu buttons. The change ensures that both `.theme-toggle` and `.mobile-menu` have a consistent appearance by removing default browser styles and setting a transparent background.

* Added CSS rules to `.theme-toggle` and `.mobile-menu` to remove default appearance and set `background-color: transparent` and `border: 0`